### PR TITLE
Support for Direct Admin Fixes #4

### DIFF
--- a/apis/direct_admin_api.php
+++ b/apis/direct_admin_api.php
@@ -1,0 +1,86 @@
+<?php
+
+class DirectAdminApi
+{
+
+    public $response_header = [];
+
+    private $url        = '';
+    private $port       = 2222;
+    private $username   = '';
+    private $password   = '';
+
+    public function __construct($url, $username, $password, $port = 2222)
+    {
+        $this->url = sprintf('%s:%d', rtrim($url, "/"), $port);
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    public function get($endpoint, array $query_params = null)
+    {
+        return $this->connect('GET', $endpoint, $query_params);
+    }
+
+    protected function connect($verb, $endpoint, array $payload = null)
+    {
+        $curl = curl_init();
+        $verb = strtoupper($verb);
+
+        // HTTP verb-specific options
+        switch($verb)
+        {
+            case 'DELETE':
+                curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+                break;
+
+            case 'GET':
+                break;
+
+            case 'PATCH':
+                $header[] = 'Content-Length: ' .  strlen($payload);
+                curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PATCH');
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
+                break;
+
+            case 'PUT':
+                $header[] = 'Content-Length: ' .  strlen($payload);
+                curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
+                break;
+
+            case 'POST':
+                $header[] = 'Content-Length: ' .  strlen($payload);
+                curl_setopt($curl, CURLOPT_POST, 1);
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
+                break;
+        }
+
+		curl_setopt($curl, CURLOPT_URL, sprintf('%s/%s%s', $this->url, $endpoint, $this->createQueryString($payload)));
+		curl_setopt($curl, CURLOPT_USERPWD, sprintf('%s:%s', $this->username, $this->password));
+		curl_setopt($curl, CURLOPT_HTTPAUTH,CURLAUTH_BASIC);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 1);
+
+        $result = curl_exec($curl);
+        $this->response_header = curl_getinfo($curl);
+        curl_close($curl);
+
+        return $result;
+    }
+
+    protected function createQueryString(array $payload)
+    {
+        if(is_null($payload) || !is_array($payload))
+            return "";
+
+        $query_string = "?";
+        foreach($payload as $key => $value)
+            $query_string .= sprintf('%s=%s&', $key, rawurlencode($value));
+
+        return rtrim($query_string, '&');
+    }
+
+}
+?>

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.1",
+    "version": "0.7.0",
     "name": "dhc.name",
     "description": "dhc.description",
     "authors": [

--- a/domain_health_check_model.php
+++ b/domain_health_check_model.php
@@ -12,6 +12,7 @@ class DomainHealthCheckModel extends AppModel {
         parent::__construct();
 
         Loader::loadModels($this, ['DomainHealthCheck.DomainResults']);
+        Loader::loadComponents($this, ['Input']);
 
         Loader::load(dirname(__FILE__) . DS . 'vendors' . DS . 'spf-lib'  . DS . 'vendor' . DS . 'autoload.php');
         Loader::load(dirname(__FILE__) . DS . 'vendors' . DS . 'net_dns2'  . DS . 'vendor' . DS . 'autoload.php');
@@ -20,6 +21,7 @@ class DomainHealthCheckModel extends AppModel {
         $this->_domainData = $this->getUploadDirectory() . 'tlds-alpha-by-domain.txt';
 
         Configure::load('domain_health_check', dirname(__FILE__) . DS . 'config' . DS);
+        Language::loadLang('domain_health_check_plugin', null, dirname(__FILE__) . DS . 'language' . DS);
     }
 
     private function getUploadDirectory()
@@ -71,6 +73,22 @@ class DomainHealthCheckModel extends AppModel {
     private function createSPF()
     {
         $this->_spf = new \SPFLib\Decoder();
+    }
+
+    public function parseJson($json, $use_array = false)
+    {
+        if (!isset($this->Json) || !($this->Json instanceof Json))
+            Loader::loadComponents($this, ['Json']);
+
+        $result = $this->Json->decode($json, $use_array);
+
+        // Set internal error
+        if (!$result) {
+            $this->Input->setErrors(['api' => ['internal' => Language::_('dhc.api.error', true)]]);
+            return;
+        }
+
+        return $result;
     }
 
     public function performHealthCheck($domain)

--- a/models/domain_health_check_panels.php
+++ b/models/domain_health_check_panels.php
@@ -1,0 +1,55 @@
+<?php
+
+class DomainHealthCheckPanels extends DomainHealthCheckModel
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function get_direct_admin_accounts(stdClass $meta, array $direct_admin_info)
+    {
+        Loader::loadModels($this, ['DomainHealthCheck.PanelDirectAdmin']);
+
+        $domains = [];
+        $direct_admin = $this->PanelDirectAdmin->api($meta->host_name, $meta->user_name, $meta->password, $meta->port, $meta->use_ssl);
+        $accounts = $this->PanelDirectAdmin->parse($direct_admin->get('CMD_ALL_USER_SHOW', ['json' => 'yes']));
+
+        if(empty($accounts))
+            return $domains[$direct_admin_info['domain']] = (object) ['domain' => $direct_admin_info['domain'], 'user' => $direct_admin_info['user'], 'suspended' => false];
+
+        foreach($accounts as $key => $account)
+        {
+            if(!is_numeric($key))
+                continue;
+
+            // Only return accounts owned by the reseller and the reseller account itself
+            if($account['creator'] !== $direct_admin_info['user'] && $account['username']['value'] !== $direct_admin_info['user'])
+                continue;
+
+            foreach($account['domains'] as $domain => $noop)
+                $domains[$domain] = (object) ['domain' => $domain, 'user' => $account['username']['value'], 'suspended' => ($account['suspended']['value'] === 'yes') ? true : false ];
+        }
+
+        return $domains;
+    }
+
+    public function get_cpanel_accounts(stdClass $meta, array $cpanel_info)
+    {
+        Loader::loadModels($this, ['DomainHealthCheck.PanelCpanel']);
+
+        $domains = [];
+        $cpanel = $this->PanelCpanel->api($meta->host_name, $meta->user_name, $meta->key, $meta->use_ssl);
+        $accounts = $this->PanelCpanel->parse($cpanel->listaccts('owner', $cpanel_info['user']));
+
+        if(empty($accounts))
+            return $domains[$cpanel_info['domain']] = (object) ['domain' => $cpanel_info['domain'], 'user' => $cpanel_info['user'], 'suspended' => false];
+
+        foreach($accounts->acct as $account)
+            $domains[$account->domain] = (object) ['domain' => $account->domain, 'user' => $account->user, 'suspended' => $account->suspended];
+
+        ksort($domains, SORT_STRING); // cPanel does not have a deterministic way returning the data
+        return $domains;
+    }
+
+}

--- a/models/panel_cpanel.php
+++ b/models/panel_cpanel.php
@@ -1,0 +1,75 @@
+<?php
+
+class PanelCpanel extends DomainHealthCheckModel
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function api($host, $user, $pass, $use_ssl = 'true')
+    {
+        // Reuse the Blesta cPanel API library
+        Loader::load(COMPONENTDIR . DS . 'modules' . DS . 'cpanel' . DS . 'apis' . DS . 'cpanel_api.php');
+
+        $api = new CpanelApi($host);
+        $api->set_user($user);
+
+        // Determine whether this is a token or a key based on length
+        if (strlen($pass) > 32) {
+            $api->set_hash($pass);
+        } else {
+            $api->set_token($pass);
+        }
+
+        $api->set_output('json');
+        $api->set_port(($use_ssl === 'true' ? 2087 : 2086));
+        $api->set_protocol('http' . ($use_ssl === 'true' ? 's' : ''));
+
+        return $api;
+    }
+
+    public function parse($json)
+    {
+        $result = $this->parseJson($json);
+        $success = true;
+
+        // Only some API requests return status, so only use it if its available
+        if (isset($result->status) && $result->status == 0) {
+            $this->Input->setErrors(['api' => ['result' => $result->statusmsg]]);
+            $success = false;
+        } elseif (isset($result->result) && is_array($result->result)
+            && isset($result->result[0]->status) && $result->result[0]->status == 0
+        ) {
+            $this->Input->setErrors(['api' => ['result' => $result->result[0]->statusmsg]]);
+            $success = false;
+        } elseif (isset($result->passwd) && is_array($result->passwd)
+            && isset($result->passwd[0]->status) && $result->passwd[0]->status == 0
+        ) {
+            $this->Input->setErrors(['api' => ['result' => $result->passwd[0]->statusmsg]]);
+            $success = false;
+        } elseif (isset($result->cpanelresult) && !empty($result->cpanelresult->error)) {
+            $this->Input->setErrors(
+                [
+                    'api' => [
+                        'error' => (isset($result->cpanelresult->data->reason)
+                            ? $result->cpanelresult->data->reason
+                            : $result->cpanelresult->error
+                        )
+                    ]
+                ]
+            );
+            $success = false;
+        }
+
+        $sensitive_data = ['/PassWord:.*?(\\\\n)/i'];
+        $replacements = ['PassWord: *****${1}'];
+
+        // Return if any errors encountered
+        if (!$success) {
+            return;
+        }
+
+        return $result;
+    }
+}

--- a/models/panel_direct_admin.php
+++ b/models/panel_direct_admin.php
@@ -1,0 +1,24 @@
+<?php
+
+class PanelDirectAdmin extends DomainHealthCheckModel
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function api($host, $user, $pass, $port, $use_ssl = 'true')
+    {
+        // Can not reuse Blesta Direct Admin library since it does not
+        // support all the endpoints and the methods are private
+        Loader::load(PLUGINDIR . 'domain_health_check' . DS . 'apis' . DS . 'direct_admin_api.php');
+
+        $url = sprintf('http%s://%s', ($use_ssl === 'true' ? 's' : ''), $host);
+        return new DirectAdminApi($url, $user, $pass, $port);
+    }
+
+    public function parse($json)
+    {
+        return $this->parseJson($json, true);
+    }
+}


### PR DESCRIPTION
Adds support for Direct Admin to domain health check plugin. This works
across both users and resellers within direct admin and fixes #4.

Signed-off-by: Adam Brenner <adam@solidnetwork.org>